### PR TITLE
fix path to grpc_cpp_plugin.exe in test_protoc.bat

### DIFF
--- a/grpc_helloworld/test_protoc.bat
+++ b/grpc_helloworld/test_protoc.bat
@@ -6,9 +6,10 @@ set path=%cd%
 set output_client_path=%path%\src\client\
 set output_server_path=%path%\src\server\
 set protoc_path=%path%\..\grpc\bin\protobuf\release
+set grpc_protoc_plugins_path=%path%\..\grpc\bin\grpc_protoc_plugins
 
-%protoc_path%\protoc.exe helloworld.proto --grpc_out=%output_client_path% --plugin=protoc-gen-grpc=%protoc_path%\grpc_cpp_plugin.exe --proto_path=.\
-%protoc_path%\protoc.exe helloworld.proto --grpc_out=%output_server_path% --plugin=protoc-gen-grpc=%protoc_path%\grpc_cpp_plugin.exe --proto_path=.\
+%protoc_path%\protoc.exe helloworld.proto --grpc_out=%output_client_path% --plugin=protoc-gen-grpc=%grpc_protoc_plugins_path%\grpc_cpp_plugin.exe --proto_path=.\
+%protoc_path%\protoc.exe helloworld.proto --grpc_out=%output_server_path% --plugin=protoc-gen-grpc=%grpc_protoc_plugins_path%\grpc_cpp_plugin.exe --proto_path=.\
 
 %protoc_path%\protoc.exe helloworld.proto --cpp_out=%output_client_path% --proto_path=.\
 %protoc_path%\protoc.exe helloworld.proto --cpp_out=%output_server_path% --proto_path=.\


### PR DESCRIPTION
`grpc_cpp_plugin.exe` is located in `\grpc\bin\grpc_protoc_plugins` but not `\grpc\bin\protobuf\release`.

Original error message:
```
C:\grpc-windows-master\grpc_helloworld>test_protoc.bat
--grpc_out: protoc-gen-grpc: The system cannot find the file specified.

--grpc_out: protoc-gen-grpc: The system cannot find the file specified.
```

This patch fixes this issue.